### PR TITLE
Ability to unregister the observer for the store

### DIFF
--- a/lib/project/helu.rb
+++ b/lib/project/helu.rb
@@ -7,6 +7,10 @@ class Helu
     SKPaymentQueue.defaultQueue.addTransactionObserver(self)
   end
 
+  def close_the_store
+    SKPaymentQueue.defaultQueue.removeTransactionObserver(self)
+  end
+
   def fail=(fail_block)
     @fail = fail_block
   end


### PR DESCRIPTION
If the helu store object is used in viewDidLoad as in the example, and that view is then released - then you will have messages sent to a non-existing Helu store because you did not unregister.

This piece of code should actually also come with a modification to the manual, that if your code ever throws out the Helu object, it better also close the store before doing so.
